### PR TITLE
Fixed: config.ru evaluated twice

### DIFF
--- a/lib/ripl/rack.rb
+++ b/lib/ripl/rack.rb
@@ -15,7 +15,7 @@ module Ripl::Rack
   module Commands
     extend self
     def rack
-      @rack ||= Ripl::Rack::App.new
+      Ripl::Rack::App.instance
     end
 
     def rackit!
@@ -41,6 +41,10 @@ module Ripl::Rack
 
     def actions
       ::Rack::Test::Methods::METHODS
+    end
+
+    def self.instance
+      @instance ||= self.new
     end
   end
 end


### PR DESCRIPTION
This PR fixes a problem with config.ru evaluated twice on startup. The cause of it was #rack object evaluated once in the scope of Ripl::Rack::Commands and then in global scope.

To reproduce:

```
# config.ru
puts "config.ru evaluated <= !!!"

run lambda { |env| [200, {}, ["OK"]] }
```

```
$ ripl rack
config.ru evaluated <= !!!
Loading development environment (Rack 1.2)
>> rack
config.ru evaluated <= !!!
...
```

This can lead to undesired behavior. In my project the whole middleware stack was loaded twice. Yuck!
