### PR TITLE
Update eval to avoid some problems

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables = ['ripl-rack']
   s.add_dependency 'ripl', '>= 0.7.0'
   s.add_dependency 'rack', '>= 1.0'
-  s.add_dependency 'rack-test', '~> 0.6.2'
+  s.add_dependency 'rack-test', '>= 0.6.2'
   s.files = Dir.glob(%w[{lib,test}/**/*.rb bin/* [A-Z]*.{txt,rdoc} ext/**/*.{rb,c}]) + %w{Rakefile .gemspec}
   s.extra_rdoc_files = ["README.rdoc", "LICENSE.txt"]
   s.license = 'MIT'

--- a/lib/ripl/rack.rb
+++ b/lib/ripl/rack.rb
@@ -34,8 +34,19 @@ module Ripl::Rack
 
     def initialize(config_ru=nil)
       config_ru ||= ENV['RACK_CONFIG'] || 'config.ru'
-      abort(MESSAGE % config_ru) unless File.exists? config_ru
-      @app = Kernel.eval("Rack::Builder.new { #{File.read(config_ru)} }")
+      abort(MESSAGE % config_ru) unless File.exist? config_ru
+
+      basepath = File.expand_path(config_ru)
+      body = File.read(config_ru)
+
+      file = <<~RUBY
+        Rack::Builder.new do
+          #{body}
+        end
+      RUBY
+
+      @app = Kernel.eval(file, TOPLEVEL_BINDING, basepath, 0)
+
       @env = ENV['RACK_ENV'] || 'development'
     end
 


### PR DESCRIPTION
Previously, this code `eval`ed the contents of `config.ru` in a single
line between `{ ... }` and without specifying the optional arguments to
`Kernel.eval`.

I noticed three problems that this caused:

1. if the final line in `config.ru` was a comment, it effectively
   commented out the closing `}`, turning the `eval` into a syntax
   error
2. It was not possible to use `require_relative` in `config.ru`
3. Error messages caused by exceptions in `config.ru` did not present
   a correct stack trace

These problems are addressed in this commit by:

1. Changing the body of the eval to call `Rack::Builder.new` with a
   multiline block.
2. Passing the optional arguments to eval with the original filename
   of the `config.ru` and a correct line number.

This commit also passes `TOPLEVEL_BINDING` as the optional second
parameter. I didn't experience any specific problems caused by leaving
this out, but `eval` without an explicit binding would have caused the
local variables `config_ru` and others to be in scope of the user's
`config.ru` which seems undesirable and pointless.